### PR TITLE
Closes #1 Fix: Eliminate 500ms latency spike in the proteomics inference kernel

### DIFF
--- a/__notes3/HowManyTimesRotatedTest.java
+++ b/__notes3/HowManyTimesRotatedTest.java
@@ -1,0 +1,16 @@
+package com.thealgorithms.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class HowManyTimesRotatedTest {
+
+    @Test
+    public void testHowManyTimesRotated() {
+        int[] arr1 = {5, 1, 2, 3, 4};
+        assertEquals(1, HowManyTimesRotated.rotated(arr1));
+        int[] arr2 = {15, 17, 2, 3, 5};
+        assertEquals(2, HowManyTimesRotated.rotated(arr2));
+    }
+}

--- a/__notes3/LZ77Test.java
+++ b/__notes3/LZ77Test.java
@@ -1,0 +1,223 @@
+package com.thealgorithms.compression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LZ77Test {
+
+    @Test
+    @DisplayName("Test compression and decompression of a simple repeating string")
+    void testSimpleRepeatingString() {
+        String original = "ababcbababaa";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 4);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test compression and decompression of a string with no repeats initially")
+    void testNoInitialRepeats() {
+        String original = "abcdefgh";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test compression and decompression of a longer example")
+    void testLongerExample() {
+        String original = "TOBEORNOTTOBEORTOBEORNOT";
+        List<LZ77.Token> compressed = LZ77.compress(original, 20, 10);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test empty string compression and decompression")
+    void testEmptyString() {
+        String original = "";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+        assertTrue(compressed.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test null string compression")
+    void testNullStringCompress() {
+        List<LZ77.Token> compressed = LZ77.compress(null);
+        assertTrue(compressed.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test null list decompression")
+    void testNullListDecompress() {
+        String decompressed = LZ77.decompress(null);
+        assertEquals("", decompressed);
+    }
+
+    @Test
+    @DisplayName("Test invalid buffer sizes throw exception")
+    void testInvalidBufferSizes() {
+        assertThrows(IllegalArgumentException.class, () -> LZ77.compress("test", 0, 5));
+        assertThrows(IllegalArgumentException.class, () -> LZ77.compress("test", 5, 0));
+        assertThrows(IllegalArgumentException.class, () -> LZ77.compress("test", -1, 5));
+        assertThrows(IllegalArgumentException.class, () -> LZ77.compress("test", 5, -1));
+    }
+
+    @Test
+    @DisplayName("Test string with all same characters")
+    void testAllSameCharacters() {
+        String original = "AAAAAA";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 5);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+
+        // Should achieve good compression for repeated characters
+        assertTrue(compressed.size() < original.length());
+    }
+
+    @Test
+    @DisplayName("Test string with all unique characters")
+    void testAllUniqueCharacters() {
+        String original = "abcdefghijklmnop";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 5);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+
+        // No compression expected for unique characters
+        assertEquals(original.length(), compressed.size());
+    }
+
+    @Test
+    @DisplayName("Test single character string")
+    void testSingleCharacter() {
+        String original = "a";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+        assertEquals(1, compressed.size());
+    }
+
+    @Test
+    @DisplayName("Test match that goes exactly to the end")
+    void testMatchToEnd() {
+        String original = "abcabc";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 10);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test with very small window size")
+    void testSmallWindowSize() {
+        String original = "ababababab";
+        List<LZ77.Token> compressed = LZ77.compress(original, 2, 4);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test with very small lookahead buffer")
+    void testSmallLookaheadBuffer() {
+        String original = "ababcbababaa";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 2);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test repeating pattern at the end")
+    void testRepeatingPatternAtEnd() {
+        String original = "xyzabcabcabcabc";
+        List<LZ77.Token> compressed = LZ77.compress(original, 15, 8);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test overlapping matches (run-length encoding case)")
+    void testOverlappingMatches() {
+        String original = "aaaaaa";
+        List<LZ77.Token> compressed = LZ77.compress(original, 10, 10);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test complex pattern with multiple repeats")
+    void testComplexPattern() {
+        String original = "abcabcabcxyzxyzxyz";
+        List<LZ77.Token> compressed = LZ77.compress(original, 20, 10);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test with special characters")
+    void testSpecialCharacters() {
+        String original = "hello world! @#$%^&*()";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test with numbers")
+    void testWithNumbers() {
+        String original = "1234567890123456";
+        List<LZ77.Token> compressed = LZ77.compress(original, 15, 8);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test long repeating sequence")
+    void testLongRepeatingSequence() {
+        String original = "abcdefgh".repeat(10);
+        List<LZ77.Token> compressed = LZ77.compress(original, 50, 20);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+
+        // Should achieve significant compression
+        assertTrue(compressed.size() < original.length() / 2);
+    }
+
+    @Test
+    @DisplayName("Test compression effectiveness")
+    void testCompressionEffectiveness() {
+        String original = "ababababababab";
+        List<LZ77.Token> compressed = LZ77.compress(original, 20, 10);
+
+        // Verify that compression actually reduces the data size
+        // Each token represents potentially multiple characters
+        assertTrue(compressed.size() <= original.length());
+
+        // Verify decompression
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test with mixed case letters")
+    void testMixedCase() {
+        String original = "AaBbCcAaBbCc";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+
+    @Test
+    @DisplayName("Test default parameters")
+    void testDefaultParameters() {
+        String original = "This is a test string with some repeated patterns. This is repeated.";
+        List<LZ77.Token> compressed = LZ77.compress(original);
+        String decompressed = LZ77.decompress(compressed);
+        assertEquals(original, decompressed);
+    }
+}

--- a/__notes3/NextSmallerElementTest.java
+++ b/__notes3/NextSmallerElementTest.java
@@ -1,0 +1,29 @@
+package com.thealgorithms.stacks;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class NextSmallerElementTest {
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testFindNextSmallerElements(int[] input, int[] expected) {
+        assertArrayEquals(expected, NextSmallerElement.findNextSmallerElements(input));
+    }
+
+    static Stream<Arguments> provideTestCases() {
+        return Stream.of(Arguments.of(new int[] {2, 7, 3, 5, 4, 6, 8}, new int[] {-1, 2, 2, 3, 3, 4, 6}), Arguments.of(new int[] {5}, new int[] {-1}), Arguments.of(new int[] {1, 2, 3, 4, 5}, new int[] {-1, 1, 2, 3, 4}), Arguments.of(new int[] {5, 4, 3, 2, 1}, new int[] {-1, -1, -1, -1, -1}),
+            Arguments.of(new int[] {4, 5, 2, 25}, new int[] {-1, 4, -1, 2}), Arguments.of(new int[] {}, new int[] {}));
+    }
+
+    @Test
+    void testFindNextSmallerElementsExceptions() {
+        assertThrows(IllegalArgumentException.class, () -> NextSmallerElement.findNextSmallerElements(null));
+    }
+}

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ✨ clean.sh — HYPERGLAM repo detox (macOS + Python) ✨
+# Usage:
+#   DRY_RUN=1 ./clean.sh    # preview
+#   ./clean.sh              # actually delete
+#
+# Notes:
+# - Safe-ish: skips .git and never touches outside project root.
+# - Fixes your main bug: rmrf isn't visible inside `find -exec bash -c ...` subshells.
+
+set -Eeuo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+FIND_ROOT="."
+
+say()  { printf '%b\n' "$*"; }
+ok()   { say "✅ $*"; }
+info() { say "✨ $*"; }
+warn() { say "⚠️  $*"; }
+
+rmrf() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '🧹 (dry-run) rm -rf %q\n' "$@"
+  else
+    printf '🧹 rm -rf %q\n' "$@"
+    rm -rf -- "$@"
+  fi
+}
+
+# Delete files (via find) with glam output + dry-run support
+find_del_files() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    # print what would be deleted
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -f /'
+  else
+    # print then delete (portable: no -delete surprises)
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print -exec rm -f -- {} + 2>/dev/null
+  fi
+}
+
+# Delete directories (via find) with glam output + dry-run support
+find_del_dirs() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -rf /'
+  else
+    # Use -prune + -exec rm -rf to reliably delete matching dirs
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print -prune -exec rm -rf -- {} + 2>/dev/null
+  fi
+}
+
+info "Cleaning up Python project clutter… (DRY_RUN=$DRY_RUN)"
+
+# --- Python bytecode & caches -------------------------------------------------
+info "Bytecode & caches"
+find_del_dirs "$FIND_ROOT" -name "__pycache__"
+find_del_files "$FIND_ROOT" \( -name "*.py[co]" -o -name "*.pyd" \)
+
+# --- build/dist/egg-info ------------------------------------------------------
+info "Build artifacts"
+for d in ./build ./dist ./docs/_build ./__pypackages__ ./pip-wheel-metadata; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+find_del_dirs "$FIND_ROOT" -name "*.egg-info"
+
+# --- test & typing caches -----------------------------------------------------
+info "Test/typing caches"
+for d in ./.pytest_cache ./.mypy_cache ./.ruff_cache ./htmlcov; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+# .coverage can be a file OR a dir; handle both
+[[ -e ./.coverage ]] && rmrf ./.coverage
+find_del_files "$FIND_ROOT" \( -name ".coverage" -o -name ".coverage.*" \)
+
+# --- virtual envs / env caches (optional) ------------------------------------
+info "Virtual envs / caches (optional)"
+for d in ./.venv ./.tox ./.nox ./.cache; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+
+# --- Jupyter checkpoints ------------------------------------------------------
+info "Jupyter checkpoints"
+find_del_dirs "$FIND_ROOT" -name ".ipynb_checkpoints"
+
+# --- Sphinx doctrees ----------------------------------------------------------
+info "Sphinx doctrees"
+find_del_dirs ./docs -name ".doctrees"
+find_del_files ./docs -name "*.doctree"
+
+# --- OS cruft -----------------------------------------------------------------
+info "OS cruft"
+find_del_files "$FIND_ROOT" -name ".DS_Store"
+find_del_files "$FIND_ROOT" -name "Thumbs.db"
+find_del_files "$FIND_ROOT" -name "._*"
+find_del_dirs  "$FIND_ROOT" -name ".Trashes"
+
+# --- backup/editor swap files -------------------------------------------------
+info "Backup/swap files"
+find_del_files "$FIND_ROOT" \( -name "*~" -o -name "*.swp" -o -name "*.bak" \)
+
+# --- compiled extensions (optional) ------------------------------------------
+info "Compiled extensions (optional)"
+find_del_files "$FIND_ROOT" -name "*.so"
+
+ok "Everything Done Under the Sun."


### PR DESCRIPTION
1 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.